### PR TITLE
feat: add ArduinoOTA support to WiFi subsystem for wireless flashing

### DIFF
--- a/mcu_ws/lib/ESP32WifiSubsystem/ESP32WifiSubsystem.cpp
+++ b/mcu_ws/lib/ESP32WifiSubsystem/ESP32WifiSubsystem.cpp
@@ -96,6 +96,9 @@ void ESP32WifiSubsystem::update() {
     }
 
     case WifiState::CONNECTED:
+#if ENABLE_ARDUINO_OTA
+      ArduinoOTA.handle();
+#endif
       if (now - last_health_check_ms_ >= kHealthCheckIntervalMs) {
         last_health_check_ms_ = now;
         if (WiFi.status() != WL_CONNECTED) {
@@ -120,6 +123,9 @@ void ESP32WifiSubsystem::reset() {
   consecutive_failures_ = 0;
   event_disconnected_ = false;
   event_got_ip_ = false;
+#if ENABLE_ARDUINO_OTA
+  ota_started_ = false;
+#endif
   transitionTo(WifiState::DISCONNECTED);
 }
 
@@ -171,9 +177,15 @@ void ESP32WifiSubsystem::handleConnected() {
   consecutive_failures_ = 0;
   last_health_check_ms_ = millis();
   transitionTo(WifiState::CONNECTED);
+#if ENABLE_ARDUINO_OTA
+  setupOTA();
+#endif
 }
 
 void ESP32WifiSubsystem::handleDisconnected() {
+#if ENABLE_ARDUINO_OTA
+  ota_started_ = false;
+#endif
   if (state_ == WifiState::CONNECTED) {
     retry_count_ = 0;
     transitionTo(WifiState::RECONNECTING);
@@ -188,6 +200,15 @@ void ESP32WifiSubsystem::powerCycleRadio() {
   WiFi.mode(WIFI_STA);
   applyStaticIP();
 }
+
+#if ENABLE_ARDUINO_OTA
+void ESP32WifiSubsystem::setupOTA() {
+  if (ota_started_) return;
+  ArduinoOTA.setHostname(setup_.getId());
+  ArduinoOTA.begin();
+  ota_started_ = true;
+}
+#endif
 
 }  // namespace Subsystem
 

--- a/mcu_ws/lib/ESP32WifiSubsystem/ESP32WifiSubsystem.h
+++ b/mcu_ws/lib/ESP32WifiSubsystem/ESP32WifiSubsystem.h
@@ -11,6 +11,14 @@
 #include <ThreadedSubsystem.h>
 #include <WiFi.h>
 
+#ifndef ENABLE_ARDUINO_OTA
+#define ENABLE_ARDUINO_OTA 0
+#endif
+
+#if ENABLE_ARDUINO_OTA
+#include <ArduinoOTA.h>
+#endif
+
 namespace Subsystem {
 
 /// @brief WiFi connection states driven by the internal state machine.
@@ -140,6 +148,11 @@ class ESP32WifiSubsystem : public Subsystem::ThreadedSubsystem {
   /// @brief Full radio power cycle (OFF → delay → STA) to recover from stuck
   ///        PHY or stale association state after repeated failures.
   void powerCycleRadio();
+
+#if ENABLE_ARDUINO_OTA
+  void setupOTA();
+  bool ota_started_ = false;
+#endif
 
   static void onWifiEvent(WiFiEvent_t event);
   static ESP32WifiSubsystem* s_instance_;

--- a/mcu_ws/platformio/network_config.example.ini
+++ b/mcu_ws/platformio/network_config.example.ini
@@ -11,3 +11,5 @@ agent_port = 8888
 static_ip = { 192, 168, 8, 50 }
 gateway = { 192, 168, 8, 1 }
 subnet = { 255, 255, 255, 0 }
+; OTA flashing — device IP as a plain string (used by _ota environments)
+ota_upload_port = 192.168.8.50

--- a/mcu_ws/platformio/platformio.ini
+++ b/mcu_ws/platformio/platformio.ini
@@ -64,6 +64,7 @@ build_flags =
 extends = esp32_microros_wifi
 platform = espressif32
 board = esp32dev
+board_build.partitions = min_spiffs.csv
 build_flags =
     ${esp32_microros_wifi.build_flags}
     -DLED_BUILTIN=2
@@ -77,11 +78,13 @@ build_flags =
     -DBRIDGE_ENABLE_BATTERY=1
     -DBRIDGE_ENABLE_LIDAR=1
     -DBRIDGE_ENABLE_DEBUG=1
+    -DENABLE_ARDUINO_OTA=1
 
 [env:esp32s3sense]
 extends = esp32_microros_wifi
 platform = espressif32 #platform = espressif32 @ ^6.7.0
 board = seeed_xiao_esp32s3
+board_build.partitions = min_spiffs.csv
 lib_deps =
     ${esp32_microros_wifi.lib_deps}
     espressif/esp32-camera
@@ -97,6 +100,7 @@ build_flags =
     -DBRIDGE_ENABLE_BATTERY=1
     -DBRIDGE_ENABLE_LIDAR=1
     -DBRIDGE_ENABLE_DEBUG=1
+    -DENABLE_ARDUINO_OTA=1
 
 [env:esp32devserial]
 extends = esp32_microros_serial
@@ -145,3 +149,17 @@ build_flags =
     -DDEBUG_TRANSPORT_BLUETOOTH
     -DDEBUG_LEVEL=4
 board_build.partitions = huge_app.csv
+
+; 5. OTA upload variants — flash over WiFi instead of serial.
+;    Usage: pio run -e esp32dev_ota -t upload
+;    The device must be running firmware with ENABLE_ARDUINO_OTA=1 and connected
+;    to WiFi. Set ota_upload_port in network_config.ini to the device's static IP.
+[ota_upload]
+upload_protocol = espota
+upload_port = ${network.ota_upload_port}
+
+[env:esp32dev_ota]
+extends = env:esp32dev, ota_upload
+
+[env:esp32s3sense_ota]
+extends = env:esp32s3sense, ota_upload


### PR DESCRIPTION
Integrates ArduinoOTA into ESP32WifiSubsystem behind the ENABLE_ARDUINO_OTA build flag. OTA server starts automatically when WiFi connects and re-initializes on reconnection. Configures min_spiffs partition table for dual-app OTA slots on esp32dev and esp32s3sense, adds _ota PlatformIO env variants for espota upload, and keeps serial as the default upload method.

https://claude.ai/code/session_01UrPRhQzEBspUuEuQSfDF9B