### PR TITLE
feat: YOLO-driven object seeker with tri-mode state machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ This project was developed with assistance of AI-powered code generation tools. 
 │  Nav2 (/map + /odom) ──→ /cmd_vel                                           │
 │                                                                             │
 │  Web Client ──→ Speech-to-text ──→ LLM ──→ JSON commands                   │
-│               Camera feed  ──→ Object detection ──→ mission planner        │
-│                                   ▲                                         │
-│                            ball_searcher                                    │
-│                            (frontier exploration)                           │
+│               Camera feed  ──→ YOLO (all COCO classes) ──→ object_seeker  │
+│                                   /vision/detections         │              │
+│                                                              ▼              │
+│                                                  WANDER / SEEK / DANCE     │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -125,15 +125,15 @@ seeker-robot/
 
 | Package | Purpose |
 |---------|---------|
-| `mcu_msgs` | Custom message definitions shared between ROS 2 and ESP32 firmware (`HexapodCmd.msg` with STAND/WALK/SIT/DANCE modes, `OledFrame.msg`) |
+| `mcu_msgs` | Custom message/action/service definitions shared between ROS 2 and ESP32 firmware. Includes `HexapodCmd.msg` (STAND/WALK/SIT/DANCE modes), `OledFrame.msg`, `DetectedObject.msg`, `DetectedObjectArray.msg`, `SeekObject.action`, and `PerformMove.srv`. |
 | `seeker_description` | URDF/Xacro hexapod model, `display.launch.py` for RViz |
 | `seeker_display` | OLED display nodes: `oled_sine_node` (animated demo) + `lcd_http_server` (HTTP framebuffer server on port 8384 for the ESP32 OLED) |
 | `seeker_gazebo` | Gazebo Harmonic simulation, sensor bridges, simulation launch files |
 | `seeker_media` | MP4 player: decodes video → OLED framebuffers (HTTP :8384) + audio → PCM stream (HTTP :8383), with A/V sync |
-| `seeker_navigation` | Nav2 + SLAM Toolbox + EKF configs, `ball_searcher` mission planner, real robot launch |
-| `seeker_sim` | `fake_mcu_node`: simulates ESP32 gait for testing without hardware |
+| `seeker_navigation` | Nav2 + SLAM Toolbox + EKF configs, `object_seeker` YOLO-driven mission planner (WANDER/SEEK/PERFORM_MOVE state machine), `find` CLI, real robot launch |
+| `seeker_sim` | `fake_mcu_node`: simulates ESP32 gait + dance for testing without hardware |
 | `seeker_tts` | Fish Audio TTS + local WAV file playback, re-served as a chunked HTTP PCM stream for the ESP32 speaker |
-| `seeker_vision` | YOLO object detection, DeepFace emotion detection, MJPEG camera proxy for the ESP32 camera stream |
+| `seeker_vision` | YOLO object detection (publishes all COCO detections on `/vision/detections`), DeepFace emotion detection, MJPEG camera proxy for the ESP32 camera stream |
 | `test_package` | Minimal ROS 2 node for build/workflow verification |
 
 ---
@@ -184,6 +184,7 @@ seeker-robot/
 | `/mcu/hexapod_cmd` | `mcu_msgs/HexapodCmd` | on demand | BEST_EFFORT | ROS → ESP32 | Gait mode (STAND/WALK/SIT), body height/pitch/roll |
 | `/media/play` | `std_msgs/String` | on demand | — | ROS internal | Trigger MP4 playback (absolute file path) |
 | `/media/stop` | `std_msgs/Empty` | on demand | — | ROS internal | Stop current MP4 playback |
+| `/vision/detections` | `mcu_msgs/DetectedObjectArray` | ~10 Hz | BEST_EFFORT | vision → seeker | All YOLO hits with class, confidence, bbox, and image size |
 | `/odom` | `nav_msgs/Odometry` | 50 Hz | — | EKF output | EKF-estimated odometry; orientation / roll-pitch TF from IMU |
 | `/map` | `nav_msgs/OccupancyGrid` | ~0.2 Hz | TRANSIENT_LOCAL | SLAM output | 5 cm/cell occupancy grid |
 
@@ -352,13 +353,23 @@ ros2 launch seeker_gazebo sim_slam_raw.launch.py
 # SLAM with IMU-fused EKF odometry (tests real hardware pipeline):
 ros2 launch seeker_gazebo sim_slam_ekf.launch.py
 
-# Full autonomy demo (EKF + SLAM + Nav2 + ball searcher):
-ros2 launch seeker_gazebo sim_ball_search.launch.py
+# YOLO object seeker (EKF + SLAM + Nav2 + object_seeker + gazebo_vision_node):
+ros2 launch seeker_gazebo sim_object_seek.launch.py
+```
+
+Once `sim_object_seek` is running, tell the robot to find any COCO-class object:
+
+```bash
+ros2 run seeker_navigation find teddy_bear --feedback
+ros2 run seeker_navigation find sports_ball --timeout 120 -f
+ros2 run seeker_navigation find chair
+# Return to idle exploration:
+ros2 service call /wander std_srvs/srv/Trigger
 ```
 
 **RViz Fixed Frame:**
 - `sim_teleop`, `sim_slam_raw`, `sim_slam_ekf` → `odom`
-- `sim_ball_search` → `map`
+- `sim_object_seek` → `map`
 
 ---
 

--- a/docs/wiki/Simulation.md
+++ b/docs/wiki/Simulation.md
@@ -106,27 +106,55 @@ ros2 run tf2_ros tf2_echo odom base_footprint
 
 ---
 
-## `sim_ball_search` — full autonomy demo
+## `sim_object_seek` — YOLO-driven full autonomy demo
 
-Full stack: Gazebo + fake MCU + EKF + SLAM Toolbox + Nav2 (controller, planner, behavior, BT navigator, velocity smoother, lifecycle manager) + `ball_searcher`. The robot spins 360° to seed the map, then explores frontiers via `NavigateToPose` until it spots the red ball in the camera feed and drives toward it.
+Full stack: Gazebo + fake MCU + EKF + SLAM Toolbox + Nav2 + `gazebo_vision_node` (YOLOv8 on all 80 COCO classes) + `object_seeker`. The robot starts in **WANDER** mode and autonomously frontier-explores the world. Send it a `SeekObject` action goal at any time and it will reset its map, re-explore, and approach the target.
+
+The world (`slam_test.sdf`) contains three COCO-class props from Gazebo Fuel: a **sports ball** (NW corner), a **teddy bear** (NE corner), and a **chair** (SW corner).
 
 ```bash
-ros2 launch seeker_gazebo sim_ball_search.launch.py
+ros2 launch seeker_gazebo sim_object_seek.launch.py
 ```
 
-The launch is gated behind timers to avoid lifecycle race conditions — it takes ~25–30 s before `ball_searcher` actually starts issuing goals. Watch the launch log for the timeline:
+The launch is gated behind timers to avoid lifecycle race conditions:
 
 ```
 t=0s   Gazebo + fake_mcu + robot_state_publisher + gz_bridge
-t=2s   EKF
-t=5s   SLAM Toolbox
+t=2s   EKF + scan_tilt_filter
+t=5s   SLAM Toolbox + gazebo_vision_node (YOLOv8)
 t=10s  slam_toolbox configure → activate
 t=13s  Nav2 nodes
 t=15s  Nav2 lifecycle manager
-t=25s  ball_searcher
+t=25s  object_seeker (starts in WANDER / frontier exploration)
 ```
 
-(Real hardware uses the same structure but fires SLAM at **t=4s** — see **[ROS2 Packages → seeker_navigation](ROS2-Packages.md#seeker_navigation)**.)
+**Send a seek goal (friendly CLI):**
+
+```bash
+# Underscores are converted to spaces automatically
+ros2 run seeker_navigation find teddy_bear --feedback
+ros2 run seeker_navigation find sports_ball --timeout 120 -f
+ros2 run seeker_navigation find chair
+
+# Raw action equivalent:
+ros2 action send_goal /seek_object mcu_msgs/action/SeekObject \
+  "{class_name: 'sports ball', timeout_sec: 60.0}" --feedback
+```
+
+Exit codes: `0` = found, `1` = rejected/server unavailable, `2` = timeout/failed, `130` = cancelled (Ctrl-C).
+
+Each new seek goal **resets the SLAM map and Nav2 costmaps** so the robot re-explores from scratch rather than replaying a stale map.
+
+**Other controls:**
+
+```bash
+# Return to idle exploration at any time:
+ros2 service call /wander std_srvs/srv/Trigger
+
+# Trigger a dance:
+ros2 service call /perform_move mcu_msgs/srv/PerformMove \
+  "{move_name: 'dance', duration_sec: 3.0}"
+```
 
 **Verify the stack is healthy:**
 
@@ -134,28 +162,29 @@ t=25s  ball_searcher
 ros2 lifecycle get /slam_toolbox          # active [3]
 ros2 lifecycle get /controller_server     # active [3]
 ros2 lifecycle get /planner_server        # active [3]
+ros2 topic echo /vision/detections --once # YOLO hits when object is in view
 ros2 topic echo /navigate_to_pose/_action/status
 ros2 topic echo /cmd_vel
 ```
 
 **RViz fixed frame:** `map`
-Recommended displays: `Map` (`/map`, Transient Local), `LaserScan` (`/lidar/scan`), `RobotModel`, `TF`, `Path` (`/plan`), `Costmap (local)` (`/local_costmap/costmap`), `Costmap (global)` (`/global_costmap/costmap`).
+Recommended displays: `Map` (`/map`, Transient Local), `LaserScan` (`/mcu/scan`), `RobotModel`, `TF`, `Path` (`/plan`), `Costmap (local)` (`/local_costmap/costmap`), `Costmap (global)` (`/global_costmap/costmap`).
 
 ---
 
-## Adding YOLO vision to a simulation run
+## Adding standalone YOLO vision to any simulation run
 
-The `seeker_vision` package provides a Gazebo-compatible vision node that subscribes to `/camera/image` (bridged from the Gazebo camera plugin). Run it alongside any simulation launch that publishes a camera feed:
+`gazebo_vision_node` can also be run alongside any launch that publishes `/camera/image`:
 
 ```bash
-# Terminal 1 — any sim launch that publishes /camera/image
+# Terminal 1
 ros2 launch seeker_gazebo sim_teleop.launch.py
 
-# Terminal 2 — YOLO detection on the Gazebo camera
-ros2 launch seeker_vision gazebo_cam.launch.py
+# Terminal 2 — publishes all YOLO detections on /vision/detections
+ros2 run seeker_vision gazebo_vision_node
 ```
 
-When the target object (default: `"teddy bear"`) appears in the camera view, the node publishes `true` on `/object_found` and a `MODE_DANCE` command to `/mcu/hexapod_cmd`. See **[ROS2 Packages → seeker_vision](ROS2-Packages.md#seeker_vision)** for all launch modes.
+`/vision/detections` (`mcu_msgs/DetectedObjectArray`) carries every COCO class seen in the frame — class name, confidence, bounding box centre/size, and image dimensions for bearing computation.
 
 ---
 
@@ -204,7 +233,8 @@ source install/setup.bash
 | `ros2 topic hz` reports *No new messages* but Gazebo is clearly simulating | Known DDS multicast isolation quirk — run the command in the *same* shell that launched the sim, not a fresh `docker exec`. |
 | Legs glitch / robot explodes on spawn | The `gz_spawn` node sets a `z=0.10` clearance. If you changed `NEUTRAL_KNEE` in `fake_mcu_node.py`, you may need to raise the spawn height so the body doesn't clip the ground. |
 | SLAM never activates in `sim_slam_ekf` | Check `ros2 lifecycle get /slam_toolbox`. If it's stuck in `unconfigured`, the `slam_activate` `ExecuteProcess` likely errored — look for `configure` failures in the launch output, often due to a missing TF (EKF not yet publishing). Wait longer or restart the launch. |
-| `ball_searcher` sits idle after t=25 s | Check Nav2 goal acceptance: `ros2 topic echo /navigate_to_pose/_action/status`. If you see `STATUS_REJECTED`, SLAM or the costmaps aren't fully alive yet. |
+| `object_seeker` sits idle after t=25 s | Check Nav2 goal acceptance: `ros2 topic echo /navigate_to_pose/_action/status`. If you see `STATUS_REJECTED`, SLAM or the costmaps aren't fully alive yet. |
+| YOLO never fires on the target | Run `ros2 topic echo /vision/detections --once` while the target is in camera view. If empty, check `gazebo_vision_node` is running (`ros2 node list`). Models are downloaded from Gazebo Fuel on first launch — ensure internet access or pre-cache them in `~/.gz/fuel`. |
 | Gazebo window shows the robot but no sensors publish | Check `ros2 node list` — if `ros_gz_bridge` is missing, `bridge.yaml` failed to load. The launch log will say which topic it choked on. |
 | You only see `base_link` in RViz, no map or laser | Your RViz fixed frame is wrong for this launch mode. Match the table above. |
 

--- a/ros2_ws/src/mcu_msgs/CMakeLists.txt
+++ b/ros2_ws/src/mcu_msgs/CMakeLists.txt
@@ -35,13 +35,18 @@ endif()
 find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(action_msgs REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/ExampleMsg.msg"
   "msg/HexapodCmd.msg"
   "msg/OledFrame.msg"
+  "msg/DetectedObject.msg"
+  "msg/DetectedObjectArray.msg"
   "srv/ExampleSrv.srv"
-  DEPENDENCIES std_msgs geometry_msgs
+  "srv/PerformMove.srv"
+  "action/SeekObject.action"
+  DEPENDENCIES std_msgs geometry_msgs action_msgs
 )
 
 ament_export_dependencies(rosidl_default_runtime)

--- a/ros2_ws/src/mcu_msgs/action/SeekObject.action
+++ b/ros2_ws/src/mcu_msgs/action/SeekObject.action
@@ -1,0 +1,20 @@
+# Goal — ask the robot to locate a specific COCO class and approach it.
+string  class_name          # e.g. "teddy bear", "sports ball"
+float32 timeout_sec 0.0     # 0 = no timeout
+---
+# Result — sent when the goal terminates.
+bool                    success
+geometry_msgs/Point     final_position   # robot pose in map frame at success/abort
+string                  message
+---
+# Feedback — published at ~10 Hz while the goal is active.
+uint8 STATE_WAITING_FOR_NAV2 = 0
+uint8 STATE_INITIAL_ROTATION = 1
+uint8 STATE_FRONTIER_NAV     = 2
+uint8 STATE_COVERAGE_NAV     = 3
+uint8 STATE_APPROACHING      = 4
+
+uint8   state
+float32 last_bbox_area    # pixels² of best recent match, 0 if nothing seen
+float32 last_bearing      # radians (positive = target to the left)
+uint32  nav2_goal_count

--- a/ros2_ws/src/mcu_msgs/msg/DetectedObject.msg
+++ b/ros2_ws/src/mcu_msgs/msg/DetectedObject.msg
@@ -1,0 +1,11 @@
+# Single YOLO detection in an image frame.
+# Bounding-box coordinates are in image pixels.
+
+string  class_name    # COCO class label (e.g. "teddy bear", "sports ball")
+float32 confidence    # YOLO confidence in [0, 1]
+float32 bbox_cx       # bounding-box centre x (pixels)
+float32 bbox_cy       # bounding-box centre y (pixels)
+float32 bbox_w        # bounding-box width  (pixels)
+float32 bbox_h        # bounding-box height (pixels)
+float32 image_width   # source image width  (pixels) — consumers compute bearing from bbox_cx / image_width
+float32 image_height  # source image height (pixels)

--- a/ros2_ws/src/mcu_msgs/msg/DetectedObjectArray.msg
+++ b/ros2_ws/src/mcu_msgs/msg/DetectedObjectArray.msg
@@ -1,0 +1,4 @@
+# One frame's worth of YOLO detections. Published per input image.
+
+std_msgs/Header header          # stamp copied from source image; frame_id = camera_optical_frame
+DetectedObject[] detections

--- a/ros2_ws/src/mcu_msgs/package.xml
+++ b/ros2_ws/src/mcu_msgs/package.xml
@@ -18,6 +18,7 @@
 
   <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>action_msgs</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ros2_ws/src/mcu_msgs/srv/PerformMove.srv
+++ b/ros2_ws/src/mcu_msgs/srv/PerformMove.srv
@@ -1,0 +1,8 @@
+# Trigger a pre-scripted move (e.g. "dance"). The seeker interrupts whatever
+# it is doing, runs the move for duration_sec, then returns to its prior mode.
+
+string  move_name         # currently only "dance"
+float32 duration_sec 3.0  # 0 = server default
+---
+bool   success
+string message

--- a/ros2_ws/src/seeker_gazebo/config/bridge.yaml
+++ b/ros2_ws/src/seeker_gazebo/config/bridge.yaml
@@ -32,13 +32,6 @@
   gz_type_name:   gz.msgs.LaserScan
   direction:      GZ_TO_ROS
 
-# LiDAR → /lidar/scan (used by slam_toolbox and Nav2 costmaps)
-- ros_topic_name: /lidar/scan
-  gz_topic_name:  /gz/scan
-  ros_type_name:  sensor_msgs/msg/LaserScan
-  gz_type_name:   gz.msgs.LaserScan
-  direction:      GZ_TO_ROS
-
 # Camera image
 - ros_topic_name: /camera/image
   gz_topic_name:  /gz/camera/image

--- a/ros2_ws/src/seeker_gazebo/config/slam_toolbox_params.yaml
+++ b/ros2_ws/src/seeker_gazebo/config/slam_toolbox_params.yaml
@@ -4,7 +4,7 @@ slam_toolbox:
     odom_frame: odom
     map_frame: map
     base_frame: base_footprint
-    scan_topic: /lidar/scan
+    scan_topic: /mcu/scan
     use_sim_time: true
 
     # Solver
@@ -15,16 +15,19 @@ slam_toolbox:
     ceres_dogleg_type: TRADITIONAL_DOGLEG
     ceres_loss_function: None
 
-    # Mapping — allow first scan without movement
+    # Mapping
     mode: mapping
-    minimum_travel_distance: 0.0
-    minimum_travel_heading: 0.0
-    minimum_time_interval: 0.0
+    # Only update the map when the robot has moved ≥20 cm or turned ≥0.3 rad
+    # (≈17°). Without these, every LiDAR scan during in-place rotation gets
+    # matched independently, causing ghost obstacles from pose drift.
+    minimum_travel_distance: 0.2
+    minimum_travel_heading: 0.3
+    minimum_time_interval: 0.5
 
     # Scan matching
     use_scan_matching: true
     use_scan_barycenter: true
-    scan_buffer_size: 10
+    scan_buffer_size: 20
     scan_buffer_maximum_scan_distance: 10.0
     link_match_minimum_response_fine: 0.1
     link_scan_maximum_distance: 1.5
@@ -56,12 +59,12 @@ slam_toolbox:
     use_response_expansion: true
 
     # Output
-    debug_logging: true
+    debug_logging: false
     throttle_scans: 1
     transform_publish_period: 0.02
     map_update_interval: 5.0
     resolution: 0.05
-    max_laser_range: 8.0
+    max_laser_range: 5.0
     transform_timeout: 0.2
     tf_buffer_duration: 30.0
     stack_size_to_use: 40000000

--- a/ros2_ws/src/seeker_gazebo/launch/sim_object_seek.launch.py
+++ b/ros2_ws/src/seeker_gazebo/launch/sim_object_seek.launch.py
@@ -1,0 +1,246 @@
+"""Simulation: YOLO-driven object seeker — Gazebo + fake MCU + EKF + SLAM + Nav2
++ gazebo_vision_node + object_seeker.
+
+Self-contained. No other launches required.
+
+object_seeker starts in WANDER mode and auto-explores. Trigger a seek with:
+  ros2 action send_goal /seek_object mcu_msgs/action/SeekObject \\
+    "{class_name: 'sports ball', timeout_sec: 60.0}" --feedback
+
+Trigger a dance with:
+  ros2 service call /perform_move mcu_msgs/srv/PerformMove \\
+    "{move_name: 'dance', duration_sec: 3.0}"
+
+Timeline:
+  t=0s  Gazebo + fake MCU + ROS bridges
+  t=2s  EKF starts (IMU + odom fusion)
+  t=5s  SLAM Toolbox + gazebo_vision_node (YOLO)
+  t=10s SLAM configured + activated
+  t=13s Nav2 stack
+  t=15s Nav2 lifecycle manager
+  t=25s object_seeker (WANDER → frontier exploration)
+"""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess, IncludeLaunchDescription, LogInfo, TimerAction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.actions import Node
+import xacro
+
+
+def generate_launch_description():
+    desc_pkg   = get_package_share_directory('seeker_description')
+    gz_pkg     = get_package_share_directory('seeker_gazebo')
+    nav_pkg    = get_package_share_directory('seeker_navigation')
+    ros_gz_pkg = get_package_share_directory('ros_gz_sim')
+
+    robot_description = xacro.process_file(
+        os.path.join(desc_pkg, 'urdf', 'seeker_hexapod.urdf.xacro')
+    ).toxml()
+
+    world_file  = os.path.join(gz_pkg, 'worlds', 'slam_test.sdf')
+    bridge_cfg  = os.path.join(gz_pkg, 'config', 'bridge.yaml')
+    slam_params = os.path.join(gz_pkg, 'config', 'slam_toolbox_params.yaml')
+    ekf_params  = os.path.join(nav_pkg, 'config', 'ekf_params.yaml')
+    nav2_params = os.path.join(nav_pkg, 'config', 'nav2_params.yaml')
+
+    gz_sim = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(ros_gz_pkg, 'launch', 'gz_sim.launch.py')
+        ),
+        launch_arguments={'gz_args': f'-r {world_file}'}.items(),
+    )
+
+    robot_state_pub = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        parameters=[{'robot_description': robot_description, 'use_sim_time': False}],
+        remappings=[('joint_states', '/mcu/joint_states')],
+    )
+
+    gz_spawn = Node(
+        package='ros_gz_sim',
+        executable='create',
+        arguments=['-name', 'seeker', '-topic', '/robot_description',
+                   '-x', '0', '-y', '0', '-z', '0.10'],
+        output='screen',
+    )
+
+    gz_bridge = Node(
+        package='ros_gz_bridge',
+        executable='parameter_bridge',
+        parameters=[{'config_file': bridge_cfg, 'use_sim_time': True}],
+        output='screen',
+    )
+
+    fake_mcu = Node(
+        package='seeker_sim',
+        executable='fake_mcu_node',
+        name='fake_mcu_node',
+        parameters=[{'use_sim_time': False}],
+        output='screen',
+    )
+
+    ekf_node = TimerAction(
+        period=2.0,
+        actions=[
+            Node(
+                package='robot_localization',
+                executable='ekf_node',
+                name='ekf_filter_node',
+                parameters=[ekf_params, {'use_sim_time': True}],
+                remappings=[('odometry/filtered', '/odom')],
+                output='screen',
+            )
+        ],
+    )
+
+    scan_filter = TimerAction(
+        period=2.0,
+        actions=[
+            Node(
+                package='seeker_navigation',
+                executable='scan_tilt_filter',
+                name='scan_tilt_filter',
+                parameters=[{'use_sim_time': True, 'max_tilt_rad': 0.06}],
+                output='screen',
+            )
+        ],
+    )
+
+    slam_toolbox = TimerAction(
+        period=5.0,
+        actions=[
+            Node(
+                package='slam_toolbox',
+                executable='async_slam_toolbox_node',
+                name='slam_toolbox',
+                parameters=[slam_params, {'use_sim_time': True}],
+                output='screen',
+            )
+        ],
+    )
+
+    vision_node = TimerAction(
+        period=5.0,
+        actions=[
+            Node(
+                package='seeker_vision',
+                executable='gazebo_vision_node',
+                name='gazebo_vision_node',
+                parameters=[{'use_sim_time': True}],
+                output='screen',
+            )
+        ],
+    )
+
+    slam_activate = TimerAction(
+        period=10.0,
+        actions=[
+            ExecuteProcess(
+                cmd=['bash', '-c',
+                     'ros2 lifecycle set /slam_toolbox configure '
+                     '&& sleep 2 '
+                     '&& ros2 lifecycle set /slam_toolbox activate'],
+                output='screen',
+            )
+        ],
+    )
+
+    nav2_nodes = TimerAction(
+        period=13.0,
+        actions=[
+            Node(package='nav2_controller',       executable='controller_server',
+                 name='controller_server',         parameters=[nav2_params], output='screen'),
+            Node(package='nav2_planner',           executable='planner_server',
+                 name='planner_server',            parameters=[nav2_params], output='screen'),
+            Node(package='nav2_behaviors',         executable='behavior_server',
+                 name='behavior_server',           parameters=[nav2_params], output='screen'),
+            Node(package='nav2_bt_navigator',      executable='bt_navigator',
+                 name='bt_navigator',              parameters=[nav2_params], output='screen'),
+            Node(package='nav2_velocity_smoother', executable='velocity_smoother',
+                 name='velocity_smoother',         parameters=[nav2_params], output='screen'),
+        ],
+    )
+
+    lifecycle_manager = TimerAction(
+        period=15.0,
+        actions=[
+            Node(
+                package='nav2_lifecycle_manager',
+                executable='lifecycle_manager',
+                name='lifecycle_manager_navigation',
+                parameters=[nav2_params],
+                output='screen',
+            )
+        ],
+    )
+
+    object_seeker = TimerAction(
+        period=25.0,
+        actions=[
+            Node(
+                package='seeker_navigation',
+                executable='object_seeker',
+                name='object_seeker',
+                parameters=[{'use_sim_time': True}],
+                output='screen',
+            )
+        ],
+    )
+
+    rviz = Node(
+        package='rviz2',
+        executable='rviz2',
+        arguments=['-d', os.path.join(nav_pkg, 'rviz', 'nav2.rviz')],
+        parameters=[{'use_sim_time': True}],
+        output='screen',
+    )
+
+    hint = LogInfo(
+        msg='\n'
+            '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+            '  YOLO object seeker demo launching.\n'
+            '  t=0s  Gazebo + fake MCU\n'
+            '  t=2s  EKF\n'
+            '  t=5s  SLAM Toolbox + gazebo_vision_node (YOLO)\n'
+            '  t=10s SLAM activated\n'
+            '  t=13s Nav2 stack\n'
+            '  t=15s Nav2 lifecycle manager\n'
+            '  t=25s object_seeker (WANDER mode)\n'
+            '\n'
+            '  Seek a target (friendly CLI):\n'
+            '    ros2 run seeker_navigation find teddy_bear --feedback\n'
+            '    ros2 run seeker_navigation find sports_ball --timeout 60 -f\n'
+            '    ros2 run seeker_navigation find chair\n'
+            '  Return to wander:\n'
+            '    ros2 service call /wander std_srvs/srv/Trigger\n'
+            '  Dance:\n'
+            "    ros2 service call /perform_move mcu_msgs/srv/PerformMove \\\n"
+            "      \"{move_name: 'dance', duration_sec: 3.0}\"\n"
+            '  Raw action (equivalent):\n'
+            "    ros2 action send_goal /seek_object mcu_msgs/action/SeekObject \\\n"
+            "      \"{class_name: 'sports ball', timeout_sec: 60.0}\" --feedback\n"
+            '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+    )
+
+    return LaunchDescription([
+        gz_sim,
+        robot_state_pub,
+        gz_spawn,
+        gz_bridge,
+        fake_mcu,
+        ekf_node,
+        scan_filter,
+        slam_toolbox,
+        vision_node,
+        slam_activate,
+        nav2_nodes,
+        lifecycle_manager,
+        object_seeker,
+        rviz,
+        hint,
+    ])

--- a/ros2_ws/src/seeker_gazebo/worlds/slam_test.sdf
+++ b/ros2_ws/src/seeker_gazebo/worlds/slam_test.sdf
@@ -215,27 +215,34 @@
     </model>
 
     <!-- ============================================================ -->
-    <!-- Target ball for ball-search task                              -->
-    <!-- Bright red sphere at (1.8, -1.8) — corner of the room.       -->
-    <!-- Detectable via camera HSV thresholding (red hue).            -->
+    <!-- COCO-class props for YOLO object_seeker (Fuel models)         -->
+    <!-- First launch downloads meshes to ~/.gz/fuel (needs internet). -->
     <!-- ============================================================ -->
-    <model name="target_ball">
+
+    <!-- "sports ball" — RoboCup 3D sim ball, open NW area -->
+    <include>
+      <name>sports_ball</name>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/RoboCup 3D Simulation Ball</uri>
+      <pose>-1.8 1.7 0.1 0 0 0</pose>
       <static>true</static>
-      <pose>1.8 -1.8 0.1 0 0 0</pose>
-      <link name="link">
-        <collision name="collision">
-          <geometry><sphere><radius>0.1</radius></sphere></geometry>
-        </collision>
-        <visual name="visual">
-          <geometry><sphere><radius>0.1</radius></sphere></geometry>
-          <material>
-            <ambient>1.0 0.05 0.05 1</ambient>
-            <diffuse>1.0 0.05 0.05 1</diffuse>
-            <specular>0.8 0.0 0.0 1</specular>
-          </material>
-        </visual>
-      </link>
-    </model>
+    </include>
+
+    <!-- "teddy bear" — Google photorealistic scan, open NE area -->
+    <!-- pitch=1.5707 rotates spine from lying (Y-axis) to vertical so bear stands upright -->
+    <include>
+      <name>teddy_bear</name>
+      <uri>https://fuel.gazebosim.org/1.0/GoogleResearch/models/Lovable_Huggable_Cuddly_Boutique_Teddy_Bear_Beige</uri>
+      <pose>1.70 1.60 0.20 1.51 0.25 -1.22</pose>
+      <static>true</static>
+    </include>
+
+    <!-- "chair" — open SW area, clear of l_wall_a/b -->
+    <include>
+      <name>chair</name>
+      <uri>https://fuel.gazebosim.org/1.0/OpenRobotics/models/Chair</uri>
+      <pose>-0.6 -1.6 0.0 0 0 0.8</pose>
+      <static>true</static>
+    </include>
 
   </world>
 </sdf>

--- a/ros2_ws/src/seeker_navigation/config/ekf_params.yaml
+++ b/ros2_ws/src/seeker_navigation/config/ekf_params.yaml
@@ -14,6 +14,20 @@ ekf_filter_node:
     base_link_frame: base_footprint  # EKF publishes odom->base_footprint with roll/pitch
     world_frame: odom
 
+    # --- Odometry: /odom (nav_msgs/Odometry, ground truth in sim / wheel odom on real robot) ---
+    odom0: /odom
+    odom0_config:
+      # State vector: [x, y, z, roll, pitch, yaw, vx, vy, vz, vroll, vpitch, vyaw, ax, ay, az]
+      - [true,  true,  false,
+         false, false, true,
+         false, false, false,
+         false, false, false,
+         false, false, false]
+    odom0_differential: false
+    odom0_relative: false
+    odom0_queue_size: 10
+    odom0_nodelay: false
+
     # --- IMU: /mcu/imu (sensor_msgs/Imu from BNO085 via MicroRosBridge) ---
     # The BNO085 game rotation vector fills orientation.{x,y,z,w} with absolute
     # roll/pitch derived from gravity (drift-free). Angular velocity and linear

--- a/ros2_ws/src/seeker_navigation/config/nav2_params.yaml
+++ b/ros2_ws/src/seeker_navigation/config/nav2_params.yaml
@@ -153,14 +153,14 @@ local_costmap:
         enabled: true
         observation_sources: scan
         scan:
-          topic: /lidar/scan
+          topic: /mcu/scan
           max_obstacle_height: 2.0
           clearing: true
           marking: true
           data_type: "LaserScan"
-          raytrace_max_range: 8.0
+          raytrace_max_range: 6.0
           raytrace_min_range: 0.1
-          obstacle_max_range: 7.5
+          obstacle_max_range: 5.5
           obstacle_min_range: 0.1
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
@@ -190,14 +190,14 @@ global_costmap:
         enabled: true
         observation_sources: scan
         scan:
-          topic: /lidar/scan
+          topic: /mcu/scan
           max_obstacle_height: 2.0
           clearing: true
           marking: true
           data_type: "LaserScan"
-          raytrace_max_range: 8.0
+          raytrace_max_range: 6.0
           raytrace_min_range: 0.1
-          obstacle_max_range: 7.5
+          obstacle_max_range: 5.5
           obstacle_min_range: 0.1
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"

--- a/ros2_ws/src/seeker_navigation/package.xml
+++ b/ros2_ws/src/seeker_navigation/package.xml
@@ -15,6 +15,7 @@
   <exec_depend>nav_msgs</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>
   <exec_depend>nav2_bringup</exec_depend>
+  <exec_depend>lifecycle_msgs</exec_depend>
   <exec_depend>slam_toolbox</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>robot_localization</exec_depend>

--- a/ros2_ws/src/seeker_navigation/seeker_navigation/find.py
+++ b/ros2_ws/src/seeker_navigation/seeker_navigation/find.py
@@ -1,0 +1,186 @@
+"""find — friendly CLI wrapper around the /seek_object action.
+
+Usage:
+  ros2 run seeker_navigation find teddy_bear
+  ros2 run seeker_navigation find "sports ball" --timeout 60
+  ros2 run seeker_navigation find chair -f
+
+Class names that contain spaces (e.g. "teddy bear", "sports ball") may also be
+written with underscores — "teddy_bear", "sports_ball" — which makes them easier
+to type without quoting.
+"""
+
+import argparse
+import math
+import sys
+
+import rclpy
+from rclpy.action import ActionClient
+from rclpy.node import Node
+from rclpy.utilities import remove_ros_args
+
+from mcu_msgs.action import SeekObject
+
+
+_STATE_NAMES = {
+    SeekObject.Feedback.STATE_WAITING_FOR_NAV2: 'WAITING_FOR_NAV2',
+    SeekObject.Feedback.STATE_INITIAL_ROTATION: 'INITIAL_ROTATION',
+    SeekObject.Feedback.STATE_FRONTIER_NAV:     'FRONTIER_NAV',
+    SeekObject.Feedback.STATE_COVERAGE_NAV:     'COVERAGE_NAV',
+    SeekObject.Feedback.STATE_APPROACHING:      'APPROACHING',
+}
+
+
+class FindCli(Node):
+    def __init__(self) -> None:
+        super().__init__('seeker_find_cli')
+        self._client = ActionClient(self, SeekObject, '/seek_object')
+        self._goal_handle = None
+        self._last_state: int | None = None
+
+    # --------------------------------------------------------------
+
+    def wait_for_server(self, timeout_sec: float = 5.0) -> bool:
+        return self._client.wait_for_server(timeout_sec=timeout_sec)
+
+    def send_goal(self, class_name: str, timeout_sec: float,
+                  show_feedback: bool) -> int:
+        goal = SeekObject.Goal()
+        goal.class_name = class_name
+        goal.timeout_sec = float(timeout_sec)
+
+        print(f"-> seeking '{class_name}' "
+              f"(timeout={timeout_sec:g}s{' with feedback' if show_feedback else ''})")
+
+        feedback_cb = self._feedback_cb if show_feedback else None
+        send_future = self._client.send_goal_async(
+            goal, feedback_callback=feedback_cb)
+        rclpy.spin_until_future_complete(self, send_future)
+
+        gh = send_future.result()
+        if gh is None or not gh.accepted:
+            print('[FAIL] goal rejected by server')
+            return 1
+        self._goal_handle = gh
+        print('[OK]   goal accepted, waiting for result...')
+
+        result_future = gh.get_result_async()
+        rclpy.spin_until_future_complete(self, result_future)
+
+        wrapped = result_future.result()
+        if wrapped is None:
+            print('[FAIL] no result received')
+            return 1
+        result = wrapped.result
+
+        if result.success:
+            p = result.final_position
+            print(f"[DONE] SUCCESS: {result.message}")
+            print(f"       final position (map): "
+                  f"x={p.x:+.2f}  y={p.y:+.2f}  z={p.z:+.2f}")
+            return 0
+
+        print(f"[DONE] FAILED: {result.message}")
+        return 2
+
+    # --------------------------------------------------------------
+
+    def _feedback_cb(self, fb_msg) -> None:
+        fb = fb_msg.feedback
+        state_name = _STATE_NAMES.get(fb.state, f'UNKNOWN({fb.state})')
+        transition = fb.state != self._last_state
+        self._last_state = fb.state
+
+        if fb.last_bbox_area > 0.0:
+            bearing = f'{math.degrees(fb.last_bearing):+6.1f} deg'
+            bbox = f'{int(fb.last_bbox_area):>6d} px^2'
+            target = f'target bbox={bbox} bearing={bearing}'
+        else:
+            target = 'target not seen'
+
+        prefix = '>>' if transition else '  '
+        print(f'{prefix} [{state_name:<17}] goals={fb.nav2_goal_count:<3}  {target}')
+
+    # --------------------------------------------------------------
+
+    def cancel(self) -> None:
+        if self._goal_handle is None:
+            return
+        print('\n-- cancelling seek goal...')
+        fut = self._goal_handle.cancel_goal_async()
+        try:
+            rclpy.spin_until_future_complete(self, fut, timeout_sec=3.0)
+        except Exception:
+            pass
+
+
+# ------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog='ros2 run seeker_navigation find',
+        description='Tell the Seeker robot to locate a COCO-class object.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            'Examples:\n'
+            '  ros2 run seeker_navigation find teddy_bear\n'
+            '  ros2 run seeker_navigation find "sports ball" --timeout 60\n'
+            '  ros2 run seeker_navigation find chair -f\n'
+            '\n'
+            'Underscores in the class name are converted to spaces, so\n'
+            '"teddy_bear" and "teddy bear" are equivalent.\n'
+            '\n'
+            'Exit codes: 0=found, 1=rejected/unavailable, 2=failed,\n'
+            '            130=cancelled by user (Ctrl-C).'
+        ),
+    )
+    parser.add_argument(
+        'class_name',
+        help='Target COCO class (e.g. teddy_bear, "sports ball", chair).',
+    )
+    parser.add_argument(
+        '-t', '--timeout', type=float, default=120.0,
+        help='Abort after N seconds (default 120; 0 = no timeout).',
+    )
+    parser.add_argument(
+        '-f', '--feedback', action='store_true',
+        help='Stream live state/bbox/bearing feedback while seeking.',
+    )
+    return parser
+
+
+def main() -> None:
+    argv = remove_ros_args(sys.argv)[1:]
+    args = _build_parser().parse_args(argv)
+
+    class_name = args.class_name.replace('_', ' ').strip()
+    if not class_name:
+        print('[FAIL] empty class_name')
+        sys.exit(1)
+
+    rclpy.init()
+    node = FindCli()
+    rc = 1
+    try:
+        if not node.wait_for_server(timeout_sec=5.0):
+            print("[FAIL] action server '/seek_object' not available "
+                  '(is object_seeker running?)')
+            rc = 1
+        else:
+            rc = node.send_goal(class_name, args.timeout, args.feedback)
+    except KeyboardInterrupt:
+        try:
+            node.cancel()
+        except Exception:
+            pass
+        rc = 130
+    finally:
+        try:
+            node.destroy_node()
+        except Exception:
+            pass
+        try:
+            rclpy.shutdown()
+        except Exception:
+            pass
+    sys.exit(rc)

--- a/ros2_ws/src/seeker_navigation/seeker_navigation/object_seeker.py
+++ b/ros2_ws/src/seeker_navigation/seeker_navigation/object_seeker.py
@@ -1,0 +1,987 @@
+#!/usr/bin/env python3
+"""YOLO-driven object seeker with a tri-mode state machine.
+
+Modes
+-----
+WANDER        — frontier/coverage exploration with no target; the default
+                at startup and the mode resumed after a cancel or reached.
+SEEK          — activated by a `SeekObject` action goal. Explores while
+                watching `/vision/detections` for the requested COCO class
+                and approaches when the bbox is large enough.
+PERFORM_MOVE  — transient; triggered by the `PerformMove` service. Emits a
+                `HexapodCmd(MODE_DANCE)` plus a spin `cmd_vel` for sim
+                visibility, then restores the prior mode.
+
+Sub-state within WANDER / SEEK:
+  WAITING_FOR_NAV2 -> INITIAL_ROTATION -> FRONTIER_NAV -> COVERAGE_NAV
+                                                       +-> APPROACH_OBJECT
+                                                       +-> OBJECT_REACHED
+
+Topics / interfaces
+-------------------
+  Subscribed:  /vision/detections  (mcu_msgs/DetectedObjectArray)
+               /map                (nav_msgs/OccupancyGrid)
+  Published:   /cmd_vel            (geometry_msgs/Twist) [rotate / spin]
+               /mcu/hexapod_cmd    (mcu_msgs/HexapodCmd) [dance]
+  Action:      /navigate_to_pose   (nav2_msgs/NavigateToPose) — client
+  Action:      /seek_object        (mcu_msgs/action/SeekObject) — server
+  Service:     /perform_move       (mcu_msgs/srv/PerformMove) — server
+  Service:     /wander             (std_srvs/Trigger) — cancel seek, resume exploration
+"""
+
+import enum
+import math
+import time
+from collections import deque
+
+import numpy as np
+import rclpy
+from rclpy.node import Node
+from rclpy.action import ActionClient, ActionServer, CancelResponse, GoalResponse
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.qos import QoSProfile, DurabilityPolicy, ReliabilityPolicy
+from action_msgs.msg import GoalStatus
+from geometry_msgs.msg import Twist, Quaternion, Point
+from nav_msgs.msg import OccupancyGrid
+from nav2_msgs.action import NavigateToPose
+from tf2_ros import Buffer, TransformListener
+
+from std_srvs.srv import Trigger
+from lifecycle_msgs.msg import Transition
+from lifecycle_msgs.srv import ChangeState
+from nav2_msgs.srv import ClearEntireCostmap
+from mcu_msgs.msg import DetectedObjectArray, HexapodCmd
+from mcu_msgs.srv import PerformMove
+from mcu_msgs.action import SeekObject
+
+
+# ---------------------------------------------------------------------------
+# Tuning constants
+# ---------------------------------------------------------------------------
+
+ROTATION_SPEED = 0.2            # rad/s — slow enough for SLAM scan matching to keep up
+
+MIN_BBOX_AREA      = 2500.0     # px² — min bbox area to trigger approach
+REACHED_BBOX_AREA  = 18000.0    # px² — bbox this big = close enough
+MIN_CONFIDENCE     = 0.35       # YOLO confidence threshold
+
+APPROACH_DISTANCE = 0.5         # metres per approach step
+CAMERA_HFOV       = 1.396       # rad — matches seeker_hexapod.urdf.xacro
+
+MIN_FRONTIER_SIZE     = 3
+VISITED_RADIUS        = 0.3
+MAX_VISITED_FRONTIERS = 100
+
+COVERAGE_SPACING    = 1.0
+COVERAGE_MARGIN     = 0.35
+NEAR_UNKNOWN_MARGIN = 1.5
+
+DANCE_SPIN_RATE = 1.0           # rad/s during a PERFORM_MOVE dance
+
+
+# ---------------------------------------------------------------------------
+# State machine
+# ---------------------------------------------------------------------------
+
+class Mode(enum.IntEnum):
+    WANDER = 0
+    SEEK = 1
+    PERFORM_MOVE = 2
+
+
+class SubState(enum.IntEnum):
+    WAITING_FOR_NAV2 = 0
+    INITIAL_ROTATION = 1
+    FRONTIER_NAV     = 2
+    COVERAGE_NAV     = 3
+    APPROACH_OBJECT  = 4
+    OBJECT_REACHED   = 5
+    SCAN_ROTATION    = 6  # in-place 360° scan between SEEK waypoints
+
+
+class ObjectSeeker(Node):
+    def __init__(self):
+        super().__init__("object_seeker")
+
+        cb_group = ReentrantCallbackGroup()
+
+        # -- Publishers / subscribers --
+        self._cmd_pub = self.create_publisher(Twist, "/cmd_vel", 10)
+        self._hex_pub = self.create_publisher(HexapodCmd, "/mcu/hexapod_cmd", 10)
+
+        self.create_subscription(
+            DetectedObjectArray, "/vision/detections",
+            self._on_detections, 10, callback_group=cb_group,
+        )
+
+        # slam_toolbox uses TRANSIENT_LOCAL durability on /map.
+        map_qos = QoSProfile(
+            depth=1,
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
+            reliability=ReliabilityPolicy.RELIABLE,
+        )
+        self.create_subscription(
+            OccupancyGrid, "/map", self._on_map, map_qos, callback_group=cb_group,
+        )
+
+        # -- Nav2 action client --
+        self._nav_client = ActionClient(
+            self, NavigateToPose, "navigate_to_pose", callback_group=cb_group,
+        )
+        self._current_goal_handle = None
+        self._navigating = False
+
+        # -- SLAM / Nav2 reset clients (used at start of each SEEK) --
+        # Cycling slam_toolbox's lifecycle wipes the occupancy grid; clearing the
+        # Nav2 costmaps drops any stale obstacles so the robot is forced to
+        # re-explore for each new target.
+        self._slam_lifecycle_client = self.create_client(
+            ChangeState, "/slam_toolbox/change_state", callback_group=cb_group,
+        )
+        self._clear_global_costmap_client = self.create_client(
+            ClearEntireCostmap,
+            "/global_costmap/clear_entirely_global_costmap",
+            callback_group=cb_group,
+        )
+        self._clear_local_costmap_client = self.create_client(
+            ClearEntireCostmap,
+            "/local_costmap/clear_entirely_local_costmap",
+            callback_group=cb_group,
+        )
+
+        # -- TF --
+        self._tf_buffer = Buffer()
+        self._tf_listener = TransformListener(self._tf_buffer, self)
+
+        # -- Mode + sub-state --
+        self._mode: Mode = Mode.WANDER
+        self._substate: SubState = SubState.WAITING_FOR_NAV2
+        self._prior_mode: Mode = Mode.WANDER
+        self._prior_substate: SubState = SubState.FRONTIER_NAV
+        self._target_class: str = ""
+
+        self._latest_map = None
+        self._visited_frontiers: deque[tuple[float, float]] = deque(maxlen=MAX_VISITED_FRONTIERS)
+
+        self._last_yaw = None
+        self._rotation_accumulated = 0.0
+        # State to return to after a SCAN_ROTATION completes
+        self._scan_return_substate: SubState = SubState.FRONTIER_NAV
+
+        self._frontier_retries = 0
+        self._max_frontier_retries = 10
+        self._frontier_retry_ticks = 0
+        self._frontier_retry_interval = 10
+
+        self._coverage_waypoints: list[tuple[float, float]] = []
+        self._coverage_index = 0
+
+        # Detection tracking (target class only)
+        self._target_bearing = 0.0
+        self._target_bbox_area = 0.0
+        self._approach_attempts = 0
+        self._max_approach_attempts = 15
+
+        # Action / service bookkeeping
+        self._active_goal_handle = None
+        self._nav2_goal_count = 0
+        self._final_position = Point()
+        self._dance_spinning = False
+
+        # -- Action & service servers --
+        self._seek_server = ActionServer(
+            self, SeekObject, "seek_object",
+            execute_callback=self._seek_execute,
+            goal_callback=self._seek_goal_accept,
+            cancel_callback=self._seek_cancel_accept,
+            callback_group=cb_group,
+        )
+        self._perform_srv = self.create_service(
+            PerformMove, "perform_move", self._perform_move_cb,
+            callback_group=cb_group,
+        )
+        self._wander_srv = self.create_service(
+            Trigger, "wander", self._wander_cb,
+            callback_group=cb_group,
+        )
+
+        # 10 Hz tick
+        self._dt = 0.1
+        self._timer = self.create_timer(self._dt, self._tick, callback_group=cb_group)
+
+        self.get_logger().info(
+            "ObjectSeeker started — mode=WANDER, waiting for Nav2 action server"
+        )
+
+    # ------------------------------------------------------------------
+    # Main tick (10 Hz) — advances WANDER/SEEK sub-state machine.
+    # PERFORM_MOVE is driven entirely by the service callback.
+    # ------------------------------------------------------------------
+
+    def _tick(self):
+        if self._mode == Mode.PERFORM_MOVE:
+            if self._dance_spinning:
+                self._publish_cmd(0.0, DANCE_SPIN_RATE)
+            return
+
+        if self._substate == SubState.WAITING_FOR_NAV2:
+            if self._nav_client.server_is_ready():
+                self.get_logger().info(
+                    "Nav2 action server ready — starting initial rotation"
+                )
+                self._substate = SubState.INITIAL_ROTATION
+                self._last_yaw = self._get_yaw("odom")
+                self._rotation_accumulated = 0.0
+
+        elif self._substate == SubState.INITIAL_ROTATION:
+            self._publish_cmd(linear=0.0, angular=ROTATION_SPEED)
+
+            current_yaw = self._get_yaw("odom")
+            if self._last_yaw is not None and current_yaw is not None:
+                delta = self._angle_diff(current_yaw, self._last_yaw)
+                self._rotation_accumulated += abs(delta)
+            self._last_yaw = current_yaw
+
+            if self._rotation_accumulated >= 2.0 * math.pi:
+                self._publish_cmd(0.0, 0.0)
+                self.get_logger().info(
+                    "Initial 360° rotation complete — starting frontier exploration"
+                )
+                self._substate = SubState.FRONTIER_NAV
+                self._send_next_frontier_goal()
+
+        elif self._substate == SubState.FRONTIER_NAV:
+            if not self._navigating and self._frontier_retries > 0:
+                self._frontier_retry_ticks += 1
+                if self._frontier_retry_ticks >= self._frontier_retry_interval:
+                    self._frontier_retry_ticks = 0
+                    self._send_next_frontier_goal()
+
+        elif self._substate == SubState.SCAN_ROTATION:
+            self._publish_cmd(linear=0.0, angular=ROTATION_SPEED)
+
+            current_yaw = self._get_yaw("odom")
+            if self._last_yaw is not None and current_yaw is not None:
+                delta = self._angle_diff(current_yaw, self._last_yaw)
+                self._rotation_accumulated += abs(delta)
+            self._last_yaw = current_yaw
+
+            if self._rotation_accumulated >= 2.0 * math.pi:
+                self._publish_cmd(0.0, 0.0)
+                self.get_logger().info(
+                    f"Scan-rotation complete — resuming {self._scan_return_substate.name}"
+                )
+                self._substate = self._scan_return_substate
+                if self._substate == SubState.FRONTIER_NAV:
+                    self._send_next_frontier_goal()
+                elif self._substate == SubState.COVERAGE_NAV:
+                    self._send_next_coverage_goal()
+
+        # COVERAGE_NAV, APPROACH_OBJECT, OBJECT_REACHED: goal-driven, no tick work
+
+    # ------------------------------------------------------------------
+    # Detections callback — filters by current target_class when in SEEK
+    # ------------------------------------------------------------------
+
+    def _on_detections(self, msg: DetectedObjectArray):
+        if self._mode != Mode.SEEK or not self._target_class:
+            return
+        if self._substate in (SubState.WAITING_FOR_NAV2, SubState.INITIAL_ROTATION,
+                              SubState.OBJECT_REACHED):
+            return
+
+        best = None
+        for d in msg.detections:
+            if d.class_name != self._target_class:
+                continue
+            if d.confidence < MIN_CONFIDENCE:
+                continue
+            if best is None or d.confidence > best.confidence:
+                best = d
+
+        if best is None:
+            return
+
+        area = float(best.bbox_w * best.bbox_h)
+        offset = (best.bbox_cx - best.image_width / 2.0) / best.image_width
+        bearing = -offset * CAMERA_HFOV
+
+        self._target_bearing = bearing
+        self._target_bbox_area = area
+
+        if area >= REACHED_BBOX_AREA:
+            self._on_object_reached(area)
+            return
+
+        if area >= MIN_BBOX_AREA and self._substate != SubState.APPROACH_OBJECT:
+            self._start_approach()
+
+    def _start_approach(self):
+        self._prior_substate = self._substate
+        self._substate = SubState.APPROACH_OBJECT
+        self._approach_attempts = 0
+
+        if self._current_goal_handle is not None:
+            self.get_logger().info(
+                f"Cancelling current Nav2 goal — '{self._target_class}' spotted"
+            )
+            self._current_goal_handle.cancel_goal_async()
+            self._current_goal_handle = None
+            self._navigating = False
+
+        self._send_approach_goal()
+
+    def _send_approach_goal(self):
+        if self._approach_attempts >= self._max_approach_attempts:
+            self.get_logger().warning(
+                "Max approach attempts reached — target may be unreachable"
+            )
+            self._substate = self._prior_substate or SubState.COVERAGE_NAV
+            self._on_goal_finished()
+            return
+
+        self._approach_attempts += 1
+
+        robot_x, robot_y = self._get_robot_position()
+        robot_yaw = self._get_yaw("map", default=0.0)
+        target_yaw = robot_yaw + self._target_bearing
+        goal_x = robot_x + APPROACH_DISTANCE * math.cos(target_yaw)
+        goal_y = robot_y + APPROACH_DISTANCE * math.sin(target_yaw)
+
+        self.get_logger().info(
+            f"Approaching '{self._target_class}' "
+            f"(attempt {self._approach_attempts}/{self._max_approach_attempts}): "
+            f"bearing={math.degrees(self._target_bearing):.1f}°, "
+            f"bbox_area={self._target_bbox_area:.0f}, "
+            f"goal=({goal_x:.2f}, {goal_y:.2f})"
+        )
+
+        self._navigating = True
+        self._send_nav_goal(goal_x, goal_y, "approach")
+
+    def _on_object_reached(self, bbox_area: float):
+        self._substate = SubState.OBJECT_REACHED
+
+        if self._current_goal_handle is not None:
+            self.get_logger().info("Cancelling Nav2 goal — object reached!")
+            self._current_goal_handle.cancel_goal_async()
+            self._current_goal_handle = None
+
+        self._navigating = False
+        self._publish_cmd(0.0, 0.0)
+
+        robot_x, robot_y = self._get_robot_position()
+        self._final_position.x = robot_x
+        self._final_position.y = robot_y
+        self._final_position.z = 0.0
+
+        self.get_logger().info(
+            f"OBJECT REACHED! '{self._target_class}' bbox area={bbox_area:.0f} px²"
+        )
+
+    # ------------------------------------------------------------------
+    # Map callback
+    # ------------------------------------------------------------------
+
+    def _on_map(self, msg: OccupancyGrid):
+        if self._latest_map is None:
+            self.get_logger().info(
+                f"First map received: {msg.info.width}×{msg.info.height} "
+                f"at {msg.info.resolution} m/cell"
+            )
+        self._latest_map = msg
+
+    # ------------------------------------------------------------------
+    # Frontier detection
+    # ------------------------------------------------------------------
+
+    def _find_frontiers(self):
+        if self._latest_map is None:
+            return None
+
+        grid = self._latest_map
+        width, height = grid.info.width, grid.info.height
+        resolution = grid.info.resolution
+        origin_x = grid.info.origin.position.x
+        origin_y = grid.info.origin.position.y
+
+        data = np.array(grid.data, dtype=np.int8).reshape((height, width))
+
+        free_mask = data == 0
+        unknown_mask = data == -1
+
+        padded = np.pad(unknown_mask, 1, constant_values=False)
+        unknown_neighbor = (
+            padded[:-2, 1:-1] | padded[2:, 1:-1]
+            | padded[1:-1, :-2] | padded[1:-1, 2:]
+        )
+        frontier_mask = free_mask & unknown_neighbor
+
+        if int(np.sum(frontier_mask)) == 0:
+            return None
+
+        clusters = self._cluster_frontiers(frontier_mask)
+        if not clusters:
+            return None
+
+        robot_x, robot_y = self._get_robot_position()
+        candidates = []
+        for cells in clusters:
+            if len(cells) < MIN_FRONTIER_SIZE:
+                continue
+            centroid_row = sum(c[0] for c in cells) / len(cells)
+            centroid_col = sum(c[1] for c in cells) / len(cells)
+            map_x = origin_x + centroid_col * resolution
+            map_y = origin_y + centroid_row * resolution
+            dist = math.hypot(map_x - robot_x, map_y - robot_y)
+            candidates.append((map_x, map_y, len(cells) / max(dist, 0.1)))
+
+        if not candidates:
+            return None
+
+        candidates.sort(key=lambda c: c[2], reverse=True)
+        for fx, fy, _score in candidates:
+            if all(math.hypot(fx - vx, fy - vy) >= VISITED_RADIUS
+                   for vx, vy in self._visited_frontiers):
+                return (fx, fy)
+        return None
+
+    @staticmethod
+    def _dilate_mask(mask: np.ndarray, cells: int) -> np.ndarray:
+        result = mask.copy()
+        for _ in range(cells):
+            padded = np.pad(result, 1, constant_values=False)
+            result = (
+                result | padded[:-2, 1:-1] | padded[2:, 1:-1]
+                | padded[1:-1, :-2] | padded[1:-1, 2:]
+            )
+        return result
+
+    @staticmethod
+    def _cluster_frontiers(frontier_mask):
+        height, width = frontier_mask.shape
+        visited = np.zeros_like(frontier_mask, dtype=bool)
+        clusters = []
+        for r in range(height):
+            for c in range(width):
+                if frontier_mask[r, c] and not visited[r, c]:
+                    cluster = []
+                    queue = deque([(r, c)])
+                    visited[r, c] = True
+                    while queue:
+                        cr, cc = queue.popleft()
+                        cluster.append((cr, cc))
+                        for dr, dc in ((-1, 0), (1, 0), (0, -1), (0, 1)):
+                            nr, nc = cr + dr, cc + dc
+                            if (0 <= nr < height and 0 <= nc < width
+                                    and frontier_mask[nr, nc] and not visited[nr, nc]):
+                                visited[nr, nc] = True
+                                queue.append((nr, nc))
+                    clusters.append(cluster)
+        return clusters
+
+    # ------------------------------------------------------------------
+    # Coverage waypoints
+    # ------------------------------------------------------------------
+
+    def _generate_coverage_waypoints(self):
+        if self._latest_map is None:
+            return []
+
+        grid = self._latest_map
+        width, height = grid.info.width, grid.info.height
+        resolution = grid.info.resolution
+        origin_x = grid.info.origin.position.x
+        origin_y = grid.info.origin.position.y
+
+        data = np.array(grid.data, dtype=np.int8).reshape((height, width))
+        free_mask = data == 0
+        occupied_mask = data > 0
+        margin_cells = max(1, int(COVERAGE_MARGIN / resolution))
+        safe_mask = free_mask & ~self._dilate_mask(occupied_mask, margin_cells)
+        unknown_mask = data == -1
+        proximity_cells = max(1, int(NEAR_UNKNOWN_MARGIN / resolution))
+        near_unknown = safe_mask & self._dilate_mask(unknown_mask, proximity_cells)
+
+        spacing_cells = max(1, int(COVERAGE_SPACING / resolution))
+        robot_x, robot_y = self._get_robot_position()
+
+        waypoints = []
+        for r in range(spacing_cells, height - spacing_cells, spacing_cells):
+            for c in range(spacing_cells, width - spacing_cells, spacing_cells):
+                if safe_mask[r, c]:
+                    wx = origin_x + c * resolution
+                    wy = origin_y + r * resolution
+                    priority = 0 if near_unknown[r, c] else 1
+                    dist = math.hypot(wx - robot_x, wy - robot_y)
+                    waypoints.append((wx, wy, priority, dist))
+
+        waypoints.sort(key=lambda p: (p[2], p[3]))
+        waypoints = [(w[0], w[1]) for w in waypoints]
+        self.get_logger().info(
+            f"Generated {len(waypoints)} coverage waypoints "
+            f"(spacing={COVERAGE_SPACING} m, margin={COVERAGE_MARGIN} m)"
+        )
+        return waypoints
+
+    # ------------------------------------------------------------------
+    # Nav2 goal management
+    # ------------------------------------------------------------------
+
+    def _send_next_frontier_goal(self):
+        target = self._find_frontiers()
+        if target is None:
+            self._frontier_retries += 1
+            if self._frontier_retries >= self._max_frontier_retries:
+                self.get_logger().info(
+                    "Frontier retries exhausted — switching to coverage navigation"
+                )
+                self._start_coverage_nav()
+            return
+
+        self._frontier_retries = 0
+        self._frontier_retry_ticks = 0
+        self._navigating = True
+        goal_x, goal_y = target
+        self._visited_frontiers.append((goal_x, goal_y))
+        self._send_nav_goal(goal_x, goal_y, "frontier")
+
+    def _start_coverage_nav(self):
+        self._substate = SubState.COVERAGE_NAV
+        self._coverage_waypoints = self._generate_coverage_waypoints()
+        self._coverage_index = 0
+        self._send_next_coverage_goal()
+
+    def _send_next_coverage_goal(self):
+        if self._coverage_index >= len(self._coverage_waypoints):
+            self.get_logger().info(
+                "All coverage waypoints visited — rechecking for frontiers"
+            )
+            self._substate = SubState.FRONTIER_NAV
+            self._frontier_retries = 0
+            self._frontier_retry_ticks = 0
+            self._visited_frontiers.clear()
+            self._send_next_frontier_goal()
+            return
+
+        wx, wy = self._coverage_waypoints[self._coverage_index]
+        self._coverage_index += 1
+        self.get_logger().info(
+            f"Coverage waypoint {self._coverage_index}/"
+            f"{len(self._coverage_waypoints)}: ({wx:.2f}, {wy:.2f})"
+        )
+        self._navigating = True
+        self._send_nav_goal(wx, wy, "coverage")
+
+    def _send_nav_goal(self, goal_x: float, goal_y: float, label: str):
+        robot_x, robot_y = self._get_robot_position()
+        yaw = math.atan2(goal_y - robot_y, goal_x - robot_x)
+
+        goal_msg = NavigateToPose.Goal()
+        goal_msg.pose.header.frame_id = "map"
+        goal_msg.pose.header.stamp = self.get_clock().now().to_msg()
+        goal_msg.pose.pose.position.x = goal_x
+        goal_msg.pose.pose.position.y = goal_y
+        goal_msg.pose.pose.orientation = self._yaw_to_quaternion(yaw)
+
+        self._nav2_goal_count += 1
+        self.get_logger().info(
+            f"Sending Nav2 {label} goal #{self._nav2_goal_count}: "
+            f"({goal_x:.2f}, {goal_y:.2f})"
+        )
+
+        future = self._nav_client.send_goal_async(goal_msg)
+        future.add_done_callback(self._goal_response_cb)
+
+    def _goal_response_cb(self, future):
+        goal_handle = future.result()
+        if not goal_handle.accepted:
+            self.get_logger().warning("Nav2 goal rejected — trying next")
+            self._navigating = False
+            self._on_goal_finished()
+            return
+        self._current_goal_handle = goal_handle
+        goal_handle.get_result_async().add_done_callback(self._goal_result_cb)
+
+    def _goal_result_cb(self, future):
+        self._current_goal_handle = None
+        self._navigating = False
+
+        if self._substate == SubState.OBJECT_REACHED:
+            return
+
+        status = future.result().status
+        if status == GoalStatus.STATUS_SUCCEEDED:
+            self.get_logger().info("Reached Nav2 goal — finding next target")
+        elif status == GoalStatus.STATUS_CANCELED:
+            return
+        else:
+            self.get_logger().warning(
+                f"Nav2 goal ended with status {status} — trying next target"
+            )
+        self._on_goal_finished()
+
+    def _on_goal_finished(self):
+        # In SEEK mode, scan 360° between waypoints so YOLO gets every angle.
+        # In WANDER mode, skip the scan and chain waypoints straight through.
+        if (self._mode == Mode.SEEK
+                and self._substate in (SubState.FRONTIER_NAV, SubState.COVERAGE_NAV)):
+            self._start_scan_rotation(return_to=self._substate)
+            return
+
+        if self._substate == SubState.FRONTIER_NAV:
+            self._send_next_frontier_goal()
+        elif self._substate == SubState.COVERAGE_NAV:
+            self._send_next_coverage_goal()
+        elif self._substate == SubState.APPROACH_OBJECT:
+            self._send_approach_goal()
+
+    def _start_scan_rotation(self, return_to: SubState):
+        self._scan_return_substate = return_to
+        self._substate = SubState.SCAN_ROTATION
+        self._last_yaw = self._get_yaw("odom")
+        self._rotation_accumulated = 0.0
+
+    # ------------------------------------------------------------------
+    # Map / costmap reset — wipes SLAM occupancy + Nav2 costmaps so each
+    # new SEEK goal starts from a blank slate and is forced to re-explore.
+    # ------------------------------------------------------------------
+
+    def _reset_slam_map(self, per_step_timeout: float = 3.0) -> bool:
+        # Cycle slam_toolbox through deactivate → cleanup → configure → activate.
+        # cleanup is what actually drops the occupancy grid; we re-activate so
+        # scans start accumulating into a fresh map immediately.
+        steps = (
+            ("deactivate", Transition.TRANSITION_DEACTIVATE),
+            ("cleanup",    Transition.TRANSITION_CLEANUP),
+            ("configure",  Transition.TRANSITION_CONFIGURE),
+            ("activate",   Transition.TRANSITION_ACTIVATE),
+        )
+
+        if not self._slam_lifecycle_client.wait_for_service(timeout_sec=2.0):
+            self.get_logger().warning(
+                "SLAM lifecycle service unavailable — skipping map reset"
+            )
+            return False
+
+        for name, transition_id in steps:
+            req = ChangeState.Request()
+            req.transition.id = transition_id
+            future = self._slam_lifecycle_client.call_async(req)
+
+            deadline = time.monotonic() + per_step_timeout
+            while not future.done() and time.monotonic() < deadline:
+                time.sleep(0.05)
+
+            if not future.done():
+                self.get_logger().warning(
+                    f"SLAM lifecycle '{name}' timed out — map reset aborted"
+                )
+                return False
+
+            result = future.result()
+            if result is None or not result.success:
+                self.get_logger().warning(
+                    f"SLAM lifecycle '{name}' failed — map reset aborted"
+                )
+                return False
+
+        self._latest_map = None
+        self.get_logger().info("SLAM map reset complete")
+        return True
+
+    def _clear_nav2_costmaps(self, timeout: float = 1.0) -> None:
+        for label, client in (
+            ("global", self._clear_global_costmap_client),
+            ("local",  self._clear_local_costmap_client),
+        ):
+            if not client.wait_for_service(timeout_sec=timeout):
+                self.get_logger().warning(
+                    f"{label} costmap clear service unavailable — skipping"
+                )
+                continue
+            future = client.call_async(ClearEntireCostmap.Request())
+            deadline = time.monotonic() + timeout
+            while not future.done() and time.monotonic() < deadline:
+                time.sleep(0.02)
+            if not future.done():
+                self.get_logger().warning(f"{label} costmap clear timed out")
+
+    # ------------------------------------------------------------------
+    # SeekObject action server
+    # ------------------------------------------------------------------
+
+    def _seek_goal_accept(self, goal_request):
+        if not goal_request.class_name:
+            self.get_logger().warning("SeekObject: empty class_name — rejecting")
+            return GoalResponse.REJECT
+        if self._active_goal_handle is not None:
+            self.get_logger().warning(
+                "SeekObject: rejecting new goal — another seek is already active"
+            )
+            return GoalResponse.REJECT
+        return GoalResponse.ACCEPT
+
+    def _seek_cancel_accept(self, goal_handle):
+        return CancelResponse.ACCEPT
+
+    def _seek_execute(self, goal_handle):
+        request = goal_handle.request
+        timeout_sec = float(request.timeout_sec)
+        self.get_logger().info(
+            f"SeekObject: seeking '{request.class_name}' "
+            f"(timeout={timeout_sec if timeout_sec > 0 else 'none'} s)"
+        )
+
+        self._active_goal_handle = goal_handle
+        self._target_class = request.class_name
+        self._target_bearing = 0.0
+        self._target_bbox_area = 0.0
+        self._approach_attempts = 0
+        self._mode = Mode.SEEK
+
+        # Fresh seek → drop any mid-exploration state and re-scan the full map.
+        # Without this, a seek arriving after WANDER finished exploring would
+        # inherit exhausted frontiers / a stale coverage queue and barely move.
+        if self._substate not in (SubState.WAITING_FOR_NAV2, SubState.INITIAL_ROTATION):
+            if self._current_goal_handle is not None:
+                self._current_goal_handle.cancel_goal_async()
+                self._current_goal_handle = None
+            self._navigating = False
+            self._publish_cmd(0.0, 0.0)
+
+            # Wipe SLAM map + Nav2 costmaps so the robot must re-explore.
+            self._reset_slam_map()
+            self._clear_nav2_costmaps()
+
+            self._visited_frontiers.clear()
+            self._coverage_waypoints = []
+            self._coverage_index = 0
+            self._frontier_retries = 0
+            self._frontier_retry_ticks = 0
+            # First action: rotate in place so YOLO sees everything around the
+            # current pose before committing to a nav goal.
+            self._start_scan_rotation(return_to=SubState.FRONTIER_NAV)
+
+        start_time = self.get_clock().now()
+        rate_sec = 0.1
+
+        try:
+            while rclpy.ok():
+                if goal_handle.is_cancel_requested:
+                    goal_handle.canceled()
+                    return self._finish_seek(False, "canceled")
+
+                if self._substate == SubState.OBJECT_REACHED:
+                    goal_handle.succeed()
+                    return self._finish_seek(True, "reached target")
+
+                if timeout_sec > 0:
+                    elapsed = (self.get_clock().now() - start_time).nanoseconds * 1e-9
+                    if elapsed > timeout_sec:
+                        goal_handle.abort()
+                        return self._finish_seek(False, "timeout")
+
+                fb = SeekObject.Feedback()
+                # Map internal substate to the 0..4 range declared in the action.
+                # SCAN_ROTATION is reported as INITIAL_ROTATION since it's the
+                # same user-visible behavior (in-place spin).
+                if self._substate == SubState.SCAN_ROTATION:
+                    fb.state = int(SubState.INITIAL_ROTATION)
+                elif self._substate.value <= SubState.APPROACH_OBJECT:
+                    fb.state = int(self._substate)
+                else:
+                    fb.state = int(SubState.APPROACH_OBJECT)
+                fb.last_bbox_area = float(self._target_bbox_area)
+                fb.last_bearing = float(self._target_bearing)
+                fb.nav2_goal_count = self._nav2_goal_count
+                goal_handle.publish_feedback(fb)
+
+                time.sleep(rate_sec)
+        except Exception as exc:
+            self.get_logger().error(f"SeekObject execute failed: {exc}")
+            if not goal_handle.is_cancel_requested:
+                goal_handle.abort()
+            return self._finish_seek(False, f"exception: {exc}")
+
+        return self._finish_seek(False, "shutdown")
+
+    def _finish_seek(self, success: bool, message: str) -> SeekObject.Result:
+        self._active_goal_handle = None
+        self._mode = Mode.WANDER
+        self._target_class = ""
+        # On reach, stay in OBJECT_REACHED; on cancel/timeout, resume wander.
+        if self._substate == SubState.APPROACH_OBJECT:
+            self._substate = SubState.FRONTIER_NAV
+            self._send_next_frontier_goal()
+
+        result = SeekObject.Result()
+        result.success = success
+        result.final_position = self._final_position if success else self._current_position_point()
+        result.message = message
+        return result
+
+    def _current_position_point(self) -> Point:
+        x, y = self._get_robot_position()
+        p = Point()
+        p.x, p.y, p.z = x, y, 0.0
+        return p
+
+    # ------------------------------------------------------------------
+    # PerformMove service
+    # ------------------------------------------------------------------
+
+    def _perform_move_cb(self, request: PerformMove.Request, response: PerformMove.Response):
+        move = (request.move_name or "").lower()
+        duration = request.duration_sec if request.duration_sec > 0.0 else 3.0
+
+        if move != "dance":
+            response.success = False
+            response.message = f"unknown move '{request.move_name}'"
+            self.get_logger().warning(response.message)
+            return response
+
+        self.get_logger().info(f"PerformMove: dance for {duration:.1f} s")
+
+        # Cancel nav so the robot stops before dancing
+        if self._current_goal_handle is not None:
+            self._current_goal_handle.cancel_goal_async()
+            self._current_goal_handle = None
+            self._navigating = False
+
+        self._prior_mode = self._mode
+        self._prior_substate = self._substate
+        self._mode = Mode.PERFORM_MOVE
+        self._dance_spinning = True
+
+        cmd = HexapodCmd()
+        cmd.mode = HexapodCmd.MODE_DANCE
+        self._hex_pub.publish(cmd)
+
+        time.sleep(duration)
+
+        self._dance_spinning = False
+        self._publish_cmd(0.0, 0.0)
+        cmd.mode = HexapodCmd.MODE_WALK
+        self._hex_pub.publish(cmd)
+
+        # Restore prior mode. If it was SEEK but the goal was cancelled in the
+        # meantime, fall back to WANDER.
+        if self._prior_mode == Mode.SEEK and self._active_goal_handle is None:
+            self._mode = Mode.WANDER
+        else:
+            self._mode = self._prior_mode
+        self._substate = self._prior_substate
+        if self._substate in (SubState.FRONTIER_NAV, SubState.COVERAGE_NAV) and not self._navigating:
+            self._send_next_frontier_goal()
+
+        response.success = True
+        response.message = f"dance complete ({duration:.1f} s)"
+        return response
+
+    # ------------------------------------------------------------------
+    # Wander service — drop back to exploration from any mode
+    # ------------------------------------------------------------------
+
+    def _wander_cb(self, _request: Trigger.Request, response: Trigger.Response):
+        prev_mode = self._mode
+
+        # Abort any active seek goal
+        if self._active_goal_handle is not None:
+            try:
+                self._active_goal_handle.abort()
+            except Exception:
+                pass
+            self._active_goal_handle = None
+
+        # Cancel the current Nav2 goal so the robot stops before re-exploring
+        if self._current_goal_handle is not None:
+            self._current_goal_handle.cancel_goal_async()
+            self._current_goal_handle = None
+            self._navigating = False
+
+        self._mode = Mode.WANDER
+        self._target_class = ""
+        self._target_bbox_area = 0.0
+        self._substate = SubState.FRONTIER_NAV
+        self._frontier_retries = 0
+        self._send_next_frontier_goal()
+
+        response.success = True
+        response.message = f"resumed WANDER (was {prev_mode.name})"
+        self.get_logger().info(response.message)
+        return response
+
+    # ------------------------------------------------------------------
+    # TF helpers
+    # ------------------------------------------------------------------
+
+    def _get_robot_position(self):
+        try:
+            t = self._tf_buffer.lookup_transform(
+                "map", "base_footprint", rclpy.time.Time()
+            )
+            return t.transform.translation.x, t.transform.translation.y
+        except Exception:
+            return 0.0, 0.0
+
+    def _get_yaw(self, parent_frame: str, default=None):
+        try:
+            t = self._tf_buffer.lookup_transform(
+                parent_frame, "base_footprint", rclpy.time.Time()
+            )
+            q = t.transform.rotation
+            siny_cosp = 2.0 * (q.w * q.z + q.x * q.y)
+            cosy_cosp = 1.0 - 2.0 * (q.y * q.y + q.z * q.z)
+            return math.atan2(siny_cosp, cosy_cosp)
+        except Exception:
+            return default
+
+    @staticmethod
+    def _angle_diff(a, b):
+        d = a - b
+        while d > math.pi:
+            d -= 2.0 * math.pi
+        while d < -math.pi:
+            d += 2.0 * math.pi
+        return d
+
+    @staticmethod
+    def _yaw_to_quaternion(yaw):
+        q = Quaternion()
+        q.w = math.cos(yaw / 2.0)
+        q.z = math.sin(yaw / 2.0)
+        return q
+
+    def _publish_cmd(self, linear: float, angular: float):
+        msg = Twist()
+        msg.linear.x = linear
+        msg.angular.z = angular
+        self._cmd_pub.publish(msg)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    rclpy.init()
+    node = ObjectSeeker()
+    executor = MultiThreadedExecutor(num_threads=4)
+    executor.add_node(node)
+    try:
+        executor.spin()
+    except (KeyboardInterrupt, rclpy.executors.ExternalShutdownException):
+        pass
+    finally:
+        try:
+            node._publish_cmd(0.0, 0.0)
+        except Exception:
+            pass
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/ros2_ws/src/seeker_navigation/seeker_navigation/scan_tilt_filter.py
+++ b/ros2_ws/src/seeker_navigation/seeker_navigation/scan_tilt_filter.py
@@ -1,0 +1,108 @@
+"""scan_tilt_filter — drop LiDAR rays tilted into floor/ceiling by body rock.
+
+The hexapod tripod gait pitches/rolls the body on every step. Gazebo's IMU
+sensor doesn't populate the orientation quaternion, but the EKF already fuses
+IMU angular rates (roll_rate, pitch_rate, yaw_rate) and publishes the full 3-D
+orientation in the odom→base_link TF chain. This node looks up that TF each
+scan, extracts roll/pitch, then replaces rays whose effective elevation exceeds
+max_tilt_rad with inf before republishing on /mcu/scan_filtered.
+
+SLAM and Nav2 costmaps subscribe to /mcu/scan_filtered.
+"""
+
+import math
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
+import tf2_ros
+from sensor_msgs.msg import LaserScan
+
+_SENSOR_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.BEST_EFFORT,
+    durability=DurabilityPolicy.VOLATILE,
+    depth=10,
+)
+
+
+class ScanTiltFilter(Node):
+    def __init__(self) -> None:
+        super().__init__('scan_tilt_filter')
+
+        self.declare_parameter('max_tilt_rad', 0.06)  # ~3.5 deg; tune per gait amplitude
+        self._max_tilt: float = self.get_parameter('max_tilt_rad').value
+
+        self._tf_buffer = tf2_ros.Buffer()
+        self._tf_listener = tf2_ros.TransformListener(self._tf_buffer, self)
+
+        self._scan_sub = self.create_subscription(
+            LaserScan, '/mcu/scan', self._scan_cb, _SENSOR_QOS)
+        self._pub = self.create_publisher(LaserScan, '/mcu/scan_filtered', 10)
+
+        self.get_logger().info(
+            f'scan_tilt_filter ready  max_tilt={math.degrees(self._max_tilt):.1f} deg')
+
+    # ------------------------------------------------------------------
+
+    def _get_tilt(self) -> tuple[float, float]:
+        """Return (roll, pitch) in radians from TF odom→base_link."""
+        try:
+            t = self._tf_buffer.lookup_transform(
+                'odom', 'base_link', rclpy.time.Time())
+            q = t.transform.rotation
+            sinr = 2.0 * (q.w * q.x + q.y * q.z)
+            cosr = 1.0 - 2.0 * (q.x * q.x + q.y * q.y)
+            roll = math.atan2(sinr, cosr)
+            sinp = max(-1.0, min(1.0, 2.0 * (q.w * q.y - q.z * q.x)))
+            pitch = math.asin(sinp)
+            return roll, pitch
+        except tf2_ros.LookupException:
+            return 0.0, 0.0
+        except tf2_ros.ExtrapolationException:
+            return 0.0, 0.0
+
+    def _scan_cb(self, msg: LaserScan) -> None:
+        roll, pitch = self._get_tilt()
+        threshold = self._max_tilt
+
+        ranges = list(msg.ranges)
+        angle = msg.angle_min
+        inc = msg.angle_increment
+        dropped = 0
+
+        for i in range(len(ranges)):
+            # Effective elevation of this ray given body roll/pitch:
+            #   ray body-frame direction: [cos(a), sin(a), 0]
+            #   world vertical component: -pitch*cos(a) + roll*sin(a)
+            elevation = -pitch * math.cos(angle) + roll * math.sin(angle)
+            if abs(elevation) > threshold:
+                ranges[i] = float('inf')
+                dropped += 1
+            angle += inc
+
+        if dropped and self.get_clock().now().nanoseconds % 5_000_000_000 < 100_000_000:
+            self.get_logger().debug(
+                f'tilt filter: roll={math.degrees(roll):.1f}° '
+                f'pitch={math.degrees(pitch):.1f}°  dropped {dropped}/{len(ranges)} rays')
+
+        out = LaserScan()
+        out.header = msg.header
+        out.angle_min = msg.angle_min
+        out.angle_max = msg.angle_max
+        out.angle_increment = msg.angle_increment
+        out.time_increment = msg.time_increment
+        out.scan_time = msg.scan_time
+        out.range_min = msg.range_min
+        out.range_max = msg.range_max
+        out.ranges = ranges
+        out.intensities = list(msg.intensities) if msg.intensities else []
+
+        self._pub.publish(out)
+
+
+def main(args=None) -> None:
+    rclpy.init(args=args)
+    node = ScanTiltFilter()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()

--- a/ros2_ws/src/seeker_navigation/setup.py
+++ b/ros2_ws/src/seeker_navigation/setup.py
@@ -24,6 +24,9 @@ setup(
     entry_points={
         "console_scripts": [
             "ball_searcher = seeker_navigation.ball_searcher:main",
+            "object_seeker = seeker_navigation.object_seeker:main",
+            "scan_tilt_filter = seeker_navigation.scan_tilt_filter:main",
+            "find = seeker_navigation.find:main",
         ],
     },
 )

--- a/ros2_ws/src/seeker_sim/package.xml
+++ b/ros2_ws/src/seeker_sim/package.xml
@@ -18,6 +18,7 @@
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>mcu_msgs</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ros2_ws/src/seeker_sim/seeker_sim/fake_mcu_node.py
+++ b/ros2_ws/src/seeker_sim/seeker_sim/fake_mcu_node.py
@@ -37,6 +37,7 @@ from rclpy.node import Node
 from geometry_msgs.msg import Twist
 from sensor_msgs.msg import JointState
 from std_msgs.msg import Float64
+from mcu_msgs.msg import HexapodCmd
 
 # ── Gait tuning ───────────────────────────────────────────────────────────────
 
@@ -78,6 +79,11 @@ LEG_SIDE = [1, -1, 1, -1, 1, -1]
 GROUP_A = [0, 3, 4]   # FL, MR, RL
 GROUP_B = [1, 2, 5]   # FR, ML, RR
 
+# Dance: override /cmd_vel with a yaw oscillation so the hexapod spins in place
+DANCE_DURATION = 3.0              # seconds
+DANCE_WZ_AMPLITUDE = 1.2           # rad/s peak
+DANCE_WZ_FREQ = 1.0                # Hz
+
 
 # ── Node ──────────────────────────────────────────────────────────────────────
 
@@ -91,6 +97,10 @@ class FakeMcuNode(Node):
         self._wz = 0.0
         self._vz = 0.0
         self._neutral_knee = NEUTRAL_KNEE   # adjustable at runtime via t/b keys
+
+        # Dance override: when active, ignore /cmd_vel wz and oscillate yaw
+        self._dance_until = 0.0     # wall-clock-style node time; 0 = not dancing
+        self._dance_start = 0.0
 
         # Per-leg gait phase ∈ [0, 1)
         self._phase = [0.0 if i in GROUP_A else 0.5 for i in range(6)]
@@ -106,6 +116,7 @@ class FakeMcuNode(Node):
 
 
         self.create_subscription(Twist, '/cmd_vel', self._cmd_vel_cb, 10)
+        self.create_subscription(HexapodCmd, '/mcu/hexapod_cmd', self._hexapod_cmd_cb, 10)
 
         self._last_t = self.get_clock().now().nanoseconds * 1e-9
         self.create_timer(1.0 / 100, self._update)
@@ -118,12 +129,29 @@ class FakeMcuNode(Node):
         self._wz = msg.angular.z
         self._vz = msg.linear.z
 
+    def _hexapod_cmd_cb(self, msg: HexapodCmd):
+        if msg.mode == HexapodCmd.MODE_DANCE:
+            now = self.get_clock().now().nanoseconds * 1e-9
+            self._dance_start = now
+            self._dance_until = now + DANCE_DURATION
+            self.get_logger().info(f'fake_mcu: dancing for {DANCE_DURATION:.1f}s')
+        else:
+            # Any other gait command cancels the dance
+            self._dance_until = 0.0
+
     def _update(self):
         now = self.get_clock().now().nanoseconds * 1e-9
         dt  = min(max(now - self._last_t, 0.0), 0.1)
         self._last_t = now
 
         vx, wz = self._vx, self._wz
+        if self._dance_until > 0.0:
+            if now < self._dance_until:
+                phase = 2.0 * math.pi * DANCE_WZ_FREQ * (now - self._dance_start)
+                vx = 0.0
+                wz = DANCE_WZ_AMPLITUDE * math.sin(phase)
+            else:
+                self._dance_until = 0.0
         moving = (abs(vx) + abs(self._vy) + abs(wz)) > DEAD_BAND
 
         # t/b keys → linear.z: positive = raise body (decrease knee angle),

--- a/ros2_ws/src/seeker_vision/seeker_vision/detection_utils.py
+++ b/ros2_ws/src/seeker_vision/seeker_vision/detection_utils.py
@@ -1,10 +1,15 @@
 import cv2
 from std_msgs.msg import Float32MultiArray
+from mcu_msgs.msg import DetectedObject, DetectedObjectArray
 from seeker_vision.constants import CLASS_NAMES
 
 
 def run_detection(model, img, target_name, logger):
-    """Run YOLO on img, annotate in-place. Returns (found_target, found_box)."""
+    """Run YOLO on img, annotate in-place. Returns (found_target, found_box).
+
+    Legacy helper used by the HTTP-stream `vision_core` path. The Gazebo path
+    uses `build_detection_array` below which publishes every detection.
+    """
     found_target = False
     found_box = None
 
@@ -37,4 +42,35 @@ def build_detection_msg(found_target, found_box, img_width):
         ]
     else:
         msg.data = [0.0, 0.0, float(img_width)]
+    return msg
+
+
+def build_detection_array(model, img, header):
+    """Run YOLO on img, annotate in-place, and return a DetectedObjectArray
+    containing every detection. Consumers filter by class_name downstream.
+    """
+    msg = DetectedObjectArray()
+    msg.header = header
+    h, w = img.shape[:2]
+
+    for r in model(img, stream=True):
+        for box in r.boxes:
+            cls = int(box.cls[0])
+            label = CLASS_NAMES[cls]
+            x1, y1, x2, y2 = (float(v) for v in box.xyxy[0])
+
+            d = DetectedObject()
+            d.class_name = label
+            d.confidence = float(box.conf[0])
+            d.bbox_cx = (x1 + x2) / 2.0
+            d.bbox_cy = (y1 + y2) / 2.0
+            d.bbox_w = x2 - x1
+            d.bbox_h = y2 - y1
+            d.image_width = float(w)
+            d.image_height = float(h)
+            msg.detections.append(d)
+
+            cv2.rectangle(img, (int(x1), int(y1)), (int(x2), int(y2)), (255, 0, 255), 3)
+            cv2.putText(img, label, (int(x1), int(y1)), cv2.FONT_HERSHEY_SIMPLEX, 1, (255, 0, 0), 2)
+
     return msg

--- a/ros2_ws/src/seeker_vision/seeker_vision/gazebo_vision_core.py
+++ b/ros2_ws/src/seeker_vision/seeker_vision/gazebo_vision_core.py
@@ -3,11 +3,12 @@ import cv2
 import rclpy
 from ament_index_python.packages import get_package_share_directory
 from rclpy.node import Node
-from std_msgs.msg import Bool, Float32MultiArray
+from std_msgs.msg import Bool
 from sensor_msgs.msg import Image
 from cv_bridge import CvBridge
 from ultralytics import YOLO
-from seeker_vision.detection_utils import run_detection, build_detection_msg
+from mcu_msgs.msg import DetectedObjectArray
+from seeker_vision.detection_utils import build_detection_array
 
 
 class ObjectDetectionNode(Node):
@@ -22,29 +23,30 @@ class ObjectDetectionNode(Node):
             10
         )
 
+        self.detection_pub = self.create_publisher(DetectedObjectArray, '/vision/detections', 10)
         self.found_publisher = self.create_publisher(Bool, '/object_found', 10)
-        self.detection_pub = self.create_publisher(Float32MultiArray, '/detection_detail', 10)
 
         model_path = os.path.join(
             get_package_share_directory('seeker_vision'), 'model', 'yolo26n.pt'
         )
         self.model = YOLO(model_path)
-        self.target_name = "teddy bear"
         self.has_display = bool(os.environ.get('DISPLAY'))
 
     def image_callback(self, msg):
         img = self.bridge.imgmsg_to_cv2(msg, desired_encoding='bgr8')
 
-        found_target, found_box = run_detection(self.model, img, self.target_name, self.get_logger())
+        header = msg.header
+        if not header.frame_id:
+            header.frame_id = 'camera_optical_frame'
+        detections_msg = build_detection_array(self.model, img, header)
+        self.detection_pub.publish(detections_msg)
 
-        found_msg = Bool()
-        found_msg.data = found_target
-        self.found_publisher.publish(found_msg)
-
-        self.detection_pub.publish(build_detection_msg(found_target, found_box, img.shape[1]))
+        found = Bool()
+        found.data = len(detections_msg.detections) > 0
+        self.found_publisher.publish(found)
 
         if self.has_display:
-            cv2.imshow('Webcam', img)
+            cv2.imshow('Gazebo Vision', img)
             if cv2.waitKey(1) == ord('q'):
                 rclpy.shutdown()
 

--- a/ros2_ws/src/seeker_vision/seeker_vision/vision_core.py
+++ b/ros2_ws/src/seeker_vision/seeker_vision/vision_core.py
@@ -3,19 +3,19 @@ import cv2
 import rclpy
 from ament_index_python.packages import get_package_share_directory
 from rclpy.node import Node
-from std_msgs.msg import Bool, Float32MultiArray
+from std_msgs.msg import Bool
 from ultralytics import YOLO
-from mcu_msgs.msg import HexapodCmd
-from seeker_vision.detection_utils import run_detection, build_detection_msg
+from mcu_msgs.msg import DetectedObjectArray
+from std_msgs.msg import Header
+from seeker_vision.detection_utils import build_detection_array
 
 
 class ObjectDetectionNode(Node):
     def __init__(self):
         super().__init__('object_detection_node')
 
+        self.detection_pub = self.create_publisher(DetectedObjectArray, '/vision/detections', 10)
         self.found_publisher = self.create_publisher(Bool, '/object_found', 10)
-        self.detection_pub = self.create_publisher(Float32MultiArray, '/detection_detail', 10)
-        self.pub = self.create_publisher(HexapodCmd, '/mcu/hexapod_cmd', 10)
 
         self.declare_parameter('video_source', 'http://localhost:8080/stream')
         source = self.get_parameter('video_source').get_parameter_value().string_value
@@ -27,7 +27,6 @@ class ObjectDetectionNode(Node):
             get_package_share_directory('seeker_vision'), 'model', 'yolo26n.pt'
         )
         self.model = YOLO(model_path)
-        self.target_name = "teddy bear"
         self.has_display = bool(os.environ.get('DISPLAY'))
 
         self.timer = self.create_timer(0.033, self.timer_callback)  # ~30 fps
@@ -38,18 +37,15 @@ class ObjectDetectionNode(Node):
             self.get_logger().warning("Failed to grab frame from stream.")
             return
 
-        found_target, found_box = run_detection(self.model, img, self.target_name, self.get_logger())
+        header = Header()
+        header.stamp = self.get_clock().now().to_msg()
+        header.frame_id = 'camera_optical_frame'
+        detections_msg = build_detection_array(self.model, img, header)
+        self.detection_pub.publish(detections_msg)
 
-        found_msg = Bool()
-        found_msg.data = found_target
-        self.found_publisher.publish(found_msg)
-
-        self.detection_pub.publish(build_detection_msg(found_target, found_box, img.shape[1]))
-
-        if found_target:
-            msg = HexapodCmd()
-            msg.mode = HexapodCmd.MODE_DANCE
-            self.pub.publish(msg)
+        found = Bool()
+        found.data = len(detections_msg.detections) > 0
+        self.found_publisher.publish(found)
 
         if self.has_display:
             cv2.imshow('Webcam', img)


### PR DESCRIPTION
Replaces HSV ball_searcher with a YOLO-based object_seeker that can seek any of the 80 COCO classes via a ROS 2 action, auto-explores in WANDER mode, and resets the SLAM map on every new seek goal to force re-exploration.

New interfaces (mcu_msgs):
- DetectedObject.msg / DetectedObjectArray.msg — all YOLO hits per frame
- SeekObject.action — seek goal with streaming feedback (state, bbox, bearing)
- PerformMove.srv — trigger DANCE + return to prior mode

seeker_vision:
- gazebo_vision_node / vision_core now publish all COCO detections on /vision/detections (DetectedObjectArray) instead of filtering to one class

seeker_navigation:
- object_seeker node: WANDER → SEEK → PERFORM_MOVE state machine, frontier/coverage nav, approach logic, scan-rotation between waypoints, map reset (SLAM lifecycle cycle + Nav2 costmap clear) on each seek goal
- find CLI: ros2 run seeker_navigation find teddy_bear --feedback
- scan_tilt_filter node (unused in sim; available for real hardware)

seeker_sim:
- fake_mcu_node subscribes to /mcu/hexapod_cmd and simulates dance mode

seeker_gazebo:
- sim_object_seek.launch.py: full self-contained object-seeker demo
- slam_test.sdf: sports ball, teddy bear, and chair from Gazebo Fuel
- slam_toolbox_params.yaml: tuned for scan matching stability